### PR TITLE
Copy and save links added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markugen",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markugen",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markugen",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Markdown to HTML static site generation tool",
   "repository": {
     "type": "git",

--- a/src/extensions/markedcommands.ts
+++ b/src/extensions/markedcommands.ts
@@ -14,20 +14,18 @@ export interface Options {
  * within code blocks.
  * @returns the marked extension
  */
-export default function markedCode(options:Options):MarkedExtension
+export default function markedCommands(options:Options):MarkedExtension
 {
   return {
-    walkTokens: (token) => code(token, options),
+    walkTokens: (token) => commands(token, options),
   };
 }
 
-function code(token:Token, options:Options)
+function commands(token:Token, options:Options)
 {
   if (token.type !== 'code') return;
 
-  const regex = /^markugen\. *(?<cmd>[a-z_0-9]+) +(?<args>.+)/i;
-  const match = token.text.match(regex);
-  //console.dir(match)
+  const match = token.text.match(Markugen.cmdRegex);
   if (match && match.groups && match.groups.cmd && match.groups.args)
   {
     if (match.groups.cmd === 'exec')

--- a/src/extensions/markedcopysavecode.ts
+++ b/src/extensions/markedcopysavecode.ts
@@ -1,0 +1,60 @@
+import { MarkedExtension, Tokens } from 'marked';
+import { randomUUID } from 'node:crypto';
+import Markugen from '../markugen';
+import path from 'node:path';
+
+/**
+ * Extension for adding a copy and save button to code blocks
+ * @returns the marked extension
+ */
+export default function markedCopySaveCode():MarkedExtension
+{
+  return {
+    async: false,
+    useNewRenderer: true,
+    renderer: {
+      code: (token) => code(token)
+    }
+  };
+}
+
+function code(token:Tokens.Code):string|false
+{
+  // default language
+  if (!token.lang) token.lang = 'txt';
+
+  let file = undefined;
+  const match = token.raw.match(Markugen.cmdRegex);
+  if (match && match.groups && match.groups.cmd && match.groups.args && match.groups.cmd === 'import')
+    file = path.basename(match.groups.args);
+ 
+  // create an id
+  const id = randomUUID();
+  return `<div class="markugen-code">
+  <div class="markugen-code-toolbar">
+    <div class="markugen-code-title">${file ? file : '.' + token.lang}</div>
+    <div class="markugen-spacer"></div>
+  ${copy(id)}
+  ${file ? save(id, file) : ''}
+  </div>
+  <pre class="markugen-code-content"><code id="${id}" class="hljs language-${token.lang}">${token.text}</code></pre>
+</div>`;
+}
+
+function copy(id:string)
+{
+  return `  <div title="Copy to Clipboard" class="markugen-code-copy" onclick="markugen.copyToClipboard('${id}', this)">
+      <svg height="24px" viewBox="0 -960 960 960" width="24px" fill="var(--markugen-color)">
+        <path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h167q11-35 43-57.5t70-22.5q40 0 71.5 22.5T594-840h166q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560h-80v120H280v-120h-80v560Zm280-560q17 0 28.5-11.5T520-800q0-17-11.5-28.5T480-840q-17 0-28.5 11.5T440-800q0 17 11.5 28.5T480-760Z"/>
+      </svg>
+    </div>`;
+}
+
+function save(id:string, file:string)
+{
+  return `  <div title="Save to ${file}" class="markugen-code-save" onclick="markugen.saveToFile('${id}', '${file}', this)">
+      <svg height="24px" viewBox="0 -960 960 960" width="24px" fill="var(--markugen-color)">
+        <path d="M840-680v480q0 33-23.5 56.5T760-120H200q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h480l160 160Zm-80 34L646-760H200v560h560v-446ZM480-240q50 0 85-35t35-85q0-50-35-85t-85-35q-50 0-85 35t-35 85q0 50 35 85t85 35ZM240-560h360v-160H240v160Zm-40-86v446-560 114Z"/>
+      </svg>
+    </div>`;
+}

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -14,8 +14,9 @@ import { markedHighlight } from 'marked-highlight';
 import hljs from 'highlight.js';
 import markedDocument from './extensions/markeddocument';
 import markedLinks from './extensions/markedlinks';
-import markedCode from './extensions/markedcode';
+import markedCommands from './extensions/markedcommands';
 import { tabsDirective } from './extensions/tabdirectives';
+import markedCopySaveCode from './extensions/markedcopysavecode';
 
 export interface PageConfig {
   name:string,
@@ -176,8 +177,8 @@ export default class Generator
       if (p3)
       {
         return JSON.stringify({
-          version: this.mark.version,
-          name: this.mark.name,
+          version: Markugen.version,
+          name: Markugen.name,
           date: new Date(),
           platform: os.platform() === 'win32' ? 'windows' : 'linux',
         }, null, 2);
@@ -529,7 +530,8 @@ export default class Generator
           return hljs.highlight(code, { language }).value;
         }
       }),
-      markedCode({
+      markedCopySaveCode(),
+      markedCommands({
         file: md,
         markugen: this.mark,
       }),

--- a/src/markugen.ts
+++ b/src/markugen.ts
@@ -18,16 +18,22 @@ export interface OutputLabel {
 
 export default class Markugen
 {
-  // stores the version of the app
-  public readonly version:string = version;
-  // stores the name of the app
-  public readonly name:string = name;
-  // stores the options
-  public readonly options:Options;
-  // stores the path to the package
-  public readonly root:string;
-  // the default light and dark theme
-  public readonly defaultTheme:Themes = {
+  /**
+   * The version of Markugen
+   */
+  public static readonly version:string = version;
+  /**
+   * The name of Markugen
+   */
+  public static readonly name:string = name;
+  /**
+   * Regular expression used for Markugen commands
+   */
+  public static readonly cmdRegex:RegExp = /markugen\. *(?<cmd>[a-z_0-9]+) +(?<args>.+)/i;
+  /**
+   * Default light and dark themes
+   */
+  public static readonly defaultTheme:Themes = {
     light: {
       color: 'black',
       colorSecondary: 'black',
@@ -51,6 +57,15 @@ export default class Markugen
       fontFamilyHeaders: 'Georgia Pro, Crimson, Georgia, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", STHeiti, "Microsoft YaHei", SimSun, sans-serif',
     }
   };
+
+  /**
+   * Contains the options that were given on construction
+   */
+  public readonly options:Options;
+  /**
+   * Root path to the Markugen package
+   */
+  public readonly root:string;
 
   /**
    * Constructs a new instance with the given options
@@ -87,7 +102,7 @@ export default class Markugen
 
     this.options.includeHidden = options.includeHidden ? true : false;
     this.options.clearOutput = options.clearOutput ? true : false;
-    this.options.title = options.title ? options.title : 'Markugen v' + this.version;
+    this.options.title = options.title ? options.title : 'Markugen v' + Markugen.version;
     this.options.toc = options.toc !== undefined ? options.toc : 3;
     this.setTheme();
     this.checkFavicon();
@@ -146,12 +161,12 @@ export default class Markugen
    */
   private setTheme(themes?:Themes)
   {
-    if (!themes) this.options.theme = this.defaultTheme;
+    if (!themes) this.options.theme = Markugen.defaultTheme;
     else 
     {
       this.options.theme = {
-        light: themes.light ? {...this.defaultTheme.light, ...themes.light} : this.defaultTheme.light, 
-        dark: themes.dark ? {...this.defaultTheme.dark, ...themes.dark} : this.defaultTheme.dark, 
+        light: themes.light ? {...Markugen.defaultTheme.light, ...themes.light} : Markugen.defaultTheme.light, 
+        dark: themes.dark ? {...Markugen.defaultTheme.dark, ...themes.dark} : Markugen.defaultTheme.dark, 
       };
     }
   }

--- a/templates/markugen.template.css
+++ b/templates/markugen.template.css
@@ -113,6 +113,9 @@ th {
 .markugen-hidden {
   display: none;
 }
+.markugen-spacer {
+  flex: 1;
+}
 
 /* main content styles */
 #markugen-body {
@@ -383,6 +386,39 @@ th {
   text-align: right;
 }
 
+/* Code Blocks */
+.markugen-code {
+  margin: 10px 0px;
+  max-width: fit-content;
+  background-color: var(--markugen-bg-color-secondary);
+	border-radius: 10px;
+  border: 1px solid var(--markugen-border-color);
+  box-shadow: var(--markugen-box-shadow-bottom);
+}
+.markugen-code-toolbar {
+  display: flex;
+  gap: 10px;
+  padding-top: 5px;
+  padding-left: 10px;
+  padding-right: 10px;
+  border-bottom: 1px solid var(--markugen-border-color);
+  min-height: 30px;
+  max-height: 30px;
+}
+.markugen-code-content {
+  padding: 10px;
+  margin: 0px;
+}
+.markugen-code-copy, .markugen-code-save {
+  cursor: pointer;
+}
+:not(pre) > code {
+  background-color: var(--markugen-bg-color-secondary);
+	border-radius: 0.33em;
+  padding-left: 0.33em;
+  padding-right: 0.33em;
+}
+
 /* Syntax highlighter */
 .hljs-attr, .hljs-attribute {
   color: var(--hljs-attr);
@@ -410,24 +446,6 @@ th {
 }
 .hljs-strong {
   font-weight: bold;
-}
-pre:has(code) {
-  display: block;
-  max-width: fit-content;
-  white-space: pre-wrap;
-  background-color: var(--markugen-bg-color-secondary);
-	border-radius: 10px;
-  padding: 10px;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  border: 1px solid var(--markugen-border-color);
-  box-shadow: var(--markugen-box-shadow-bottom);
-}
-:not(pre) > code {
-  background-color: var(--markugen-bg-color-secondary);
-	border-radius: 0.33em;
-  padding-left: 0.33em;
-  padding-right: 0.33em;
 }
 
 /* Markdown alerts */

--- a/templates/markugen.template.js
+++ b/templates/markugen.template.js
@@ -608,6 +608,43 @@ class Markugen
     const box = element.getBoundingClientRect();
     return box.top < window.innerHeight && box.bottom >= 0;
   }
+
+  copyToClipboard(id, feedback = null)
+  {
+    let e = document.getElementById(id); 
+    if(e) 
+    { 
+      const text = e.innerText || e.textContent;
+      navigator.clipboard.writeText(text).then(() => {
+        if (feedback)
+        {
+          const html = feedback.innerHTML;
+          feedback.innerHTML = 'Copied!';
+          setTimeout(() => feedback.innerHTML = html, 1000);
+        }
+      }); 
+    }
+  }
+  saveToFile(id, filename, feedback = null)
+  {
+    let e = document.getElementById(id); 
+    if(e) 
+    { 
+      const text = e.innerText || e.textContent;
+      const link = document.createElement('a');
+      const file = new Blob([text], { type: 'text/plain' });
+      link.href = URL.createObjectURL(file);
+      link.download = filename;
+      link.click();
+      URL.revokeObjectURL(link.href);
+      if (feedback)
+      {
+        const html = feedback.innerHTML;
+        feedback.innerHTML = 'Saved!';
+        setTimeout(() => feedback.innerHTML = html, 1000);
+      }
+    }
+  }
     
   markugen = {{ markugen }};
   sitemap = {{ sitemap }};


### PR DESCRIPTION
created extension that adds a copy code link and a save link when using markugen.import